### PR TITLE
fix msimonin/ombt-orchestrator#58

### DIFF
--- a/campaign.py
+++ b/campaign.py
@@ -24,7 +24,9 @@ def filter_3(parameters):
 
 
 def filter_params(parameters, key='nbr_clients', condition=lambda unused: True):
-    params = sorted(parameters, key=operator.itemgetter(key))
+    # sort by 'call type' first then use the key
+    # (i.e., group executions by call type then sorted incrementally by key)
+    params = sorted(parameters, key=operator.itemgetter('call_type', key))
     return (p for p in params if condition(p))
 
 

--- a/campaign.py
+++ b/campaign.py
@@ -69,7 +69,7 @@ def generate_id(params):
     return '-'.join(["%s__%s" % (replace(k), replace(v)) for k, v in sorted(params.items())])
 
 
-def campaign(broker, force, provider, conf, test, env):
+def campaign(test, provider, force, conf, env):
     config = t.load_config(conf)
     parameters = config['campaign'][test]
     sweeps = sweep(parameters)
@@ -78,13 +78,15 @@ def campaign(broker, force, provider, conf, test, env):
                            sweeps=sweeps,
                            save_sweeps=True,
                            name=test)
-    current_parameters = sweeper.get_next(TEST_CASES[test]['filtr'])
-    t.PROVIDERS[provider](broker=broker, force=force, config=config, env=current_env_dir)
+    t.PROVIDERS[provider](force=force,
+                          config=config,
+                          env=current_env_dir)
     t.inventory()
+    current_parameters = sweeper.get_next(TEST_CASES[test]['filtr'])
     while current_parameters:
         try:
             current_parameters.update({'backup_dir': generate_id(current_parameters)})
-            t.prepare(broker=broker)
+            t.prepare(broker=current_parameters['driver'])
             TEST_CASES[test]['defn'](**current_parameters)
             sweeper.done(current_parameters)
             dump_parameters(current_env_dir, current_parameters)

--- a/campaign.py
+++ b/campaign.py
@@ -24,9 +24,9 @@ def filter_3(parameters):
 
 
 def filter_params(parameters, key='nbr_clients', condition=lambda unused: True):
-    # sort by 'call type' first then use the key
-    # (i.e., group executions by call type then sorted incrementally by key)
-    params = sorted(parameters, key=operator.itemgetter('call_type', key))
+    # sort by 'driver' first, then by 'call type' and finally use the key
+    # (i.e., group executions by driver-call_type and sort incrementally by key)
+    params = sorted(parameters, key=operator.itemgetter('driver', 'call_type', key))
     return (p for p in params if condition(p))
 
 

--- a/cli.py
+++ b/cli.py
@@ -19,10 +19,10 @@ def cli():
 
 
 @cli.command(help="Claim resources from a provider and configure them")
-@click.argument('broker')
-@click.option("--provider",
-              default="vagrant",
-              help="Deploy with the given provider")
+@click.argument('provider')
+@click.option("--driver",
+              default=t.DRIVER,
+              help="Agents' bus driver")
 @click.option("--force",
               is_flag=True)
 @click.option("--conf",
@@ -30,11 +30,11 @@ def cli():
               help="Configuration file to use")
 @click.option("--env",
               help="Use this environment directory instead of the default one")
-def deploy(broker, provider, force, conf, env):
+def deploy(provider, driver, force, conf, env):
     config = t.load_config(conf)
-    t.PROVIDERS[provider](broker=broker, force=force, config=config, env=env)
+    t.PROVIDERS[provider](force=force, config=config, env=env)
     t.inventory()
-    t.prepare(broker=broker)
+    t.prepare(driver=driver, env=env)
 
 
 @cli.command(help="Claim resources on Grid'5000 (from a frontend)")
@@ -53,12 +53,12 @@ def vagrant(force):
     t.vagrant(force)
 
 
-@cli.command(help="Generate the Ansible inventory file. [after g5k,vagrant]")
+@cli.command(help="Generate the Ansible inventory file. [after g5k, vagrant]")
 def inventory():
     t.inventory()
 
 
-@cli.command(help="Configure the resources. [after g5k,vagrant and inventory]")
+@cli.command(help="Configure the resources. [after g5k, vagrant and inventory]")
 def prepare():
     t.prepare()
 

--- a/cli.py
+++ b/cli.py
@@ -250,29 +250,25 @@ def test_case_4(nbr_clients, nbr_servers, nbr_topics, nbr_calls, pause, timeout,
                   env=env)
 
 
-@cli.command(help="Performs tests according to the (swept) parameters described in configuration")
-@click.argument('broker')
+@cli.command(help="Performs a test according to the (swept) parameters described in configuration")
+@click.argument('test')
 @click.option("--provider",
               default="vagrant",
               help="Deploy with the given provider")
 @click.option("--force",
               is_flag=True,
-              help="force redeploy")
+              help="Force redeploy")
 @click.option("--conf",
               default=DEFAULT_CONF,
               help="Configuration file to use")
-@click.option("--test",
-              default="test_case_1",
-              help="Launch a test campaign given a test")
 @click.option("--env",
               default=None,
-              help="Use this environment directory instead of the default one")
-def campaign(broker, force, provider, conf, test, env):
-    c.campaign(broker=broker,
+              help="Use this environment directory")
+def campaign(test, provider, force, conf, env):
+    c.campaign(test=test,
                provider=provider,
                force=force,
                conf=conf,
-               test=test,
                env=env)
 
 

--- a/conf.yaml
+++ b/conf.yaml
@@ -9,12 +9,27 @@ campaign:
     version: ["beyondtheclouds/ombt:latest"]
     length: [1024]
     executor: ["eventlet"]
-rabbitmq:
-qdr:
-  type: complete_graph
-  args: [4]
-  qdr_image: msimonin/qdrouterd-collectd
-  qdr_version: 1.0.0
+    # driver is the adopted term in ombt for brokers or routers
+    driver: ["broker-default", "router-4"]
+  test_case_2:
+    nbr_topics: [10]
+    call_type: ["rpc-call", "rpc-cast"]
+    nbr_calls: [1000]
+    pause: [0.1]
+    timeout: [8000]
+    version: ["beyondtheclouds/ombt:latest"]
+    length: [1024]
+    executor: ["threading"]
+    driver: ["broker-default"]
+drivers:
+  broker-default:
+    type: rabbitmq
+  router-4:
+    type: qdr
+    topology: complete_graph
+    args: [4]
+    qdr_image: msimonin/qdrouterd-collectd
+    qdr_version: 1.0.0
 registry:
   type: internal
 g5k:

--- a/conf.yaml
+++ b/conf.yaml
@@ -10,7 +10,7 @@ campaign:
     length: [1024]
     executor: ["eventlet"]
     # driver is the adopted term in ombt for brokers or routers
-    driver: ["broker-default", "router-4"]
+    driver: ["broker", "router-4"]
   test_case_2:
     nbr_topics: [10]
     call_type: ["rpc-call", "rpc-cast"]
@@ -20,9 +20,10 @@ campaign:
     version: ["beyondtheclouds/ombt:latest"]
     length: [1024]
     executor: ["threading"]
-    driver: ["broker-default"]
+    driver: ["broker"]
 drivers:
-  broker-default:
+  # default broker must be present (required by enostask prepare)
+  broker:
     type: rabbitmq
   router-4:
     type: qdr
@@ -33,7 +34,7 @@ drivers:
 registry:
   type: internal
 g5k:
-  #reservation: "2017-12-06 14:40:00"
+  #reservation: "2018-03-01 14:40:00"
   walltime: "2:00:00"
   dhcp: true
   job_name: rabbitmq-xp-daytest

--- a/tasks.py
+++ b/tasks.py
@@ -16,12 +16,12 @@ NBR_CLIENTS = 1
 NBR_SERVERS = 1
 NBR_TOPICS = 1
 CALL_TYPE = "rpc-call"
-NBR_CALLS = "100"
+NBR_CALLS = 100
 PAUSE = 0.0
 TIMEOUT = 60
 VERSION = "beyondtheclouds/ombt:latest"
 BACKUP_DIR = "backup"
-LENGTH = "1024"
+LENGTH = 1024
 EXECUTOR = "threading"
 
 tc = {

--- a/tasks.py
+++ b/tasks.py
@@ -11,7 +11,7 @@ from enoslib.task import enostask
 from qpid_dispatchgen import get_conf, generate, round_robin
 
 # DEFAULT PARAMETERS
-BROKER = "qdr"
+DRIVER = "broker"
 NBR_CLIENTS = 1
 NBR_SERVERS = 1
 NBR_TOPICS = 1
@@ -325,11 +325,11 @@ def generate_bus_conf(config, machines):
 
 
 @enostask()
-def prepare(broker=BROKER, env=None, **kwargs):
+def prepare(driver=DRIVER, env=None, **kwargs):
     # Generate inventory
     extra_vars = {
         "registry": env["config"]["registry"],
-        "broker": env["config"]['drivers'][broker]['type']
+        "broker": env['config']['drivers'][driver]['type']
     }
     # Preparing the installation of the bus under evaluation
     # Need to pass specific options
@@ -338,9 +338,9 @@ def prepare(broker=BROKER, env=None, **kwargs):
     # This configuration dict is used in subsequent test* tasks to configure the
     # ombt agents.
 
-    roles = env["roles"]
+    roles = env['roles']
     # Get the config of the bus, inject the type
-    config = env["config"]['drivers'].get(broker)
+    config = env['config']['drivers'].get(driver)
 
     def generate_ansible_conf(configuration, role):
         machines = [desc.alias for desc in roles[role]]
@@ -354,8 +354,8 @@ def prepare(broker=BROKER, env=None, **kwargs):
         return ansible_conf
 
     ansible_bus_conf = generate_ansible_conf(config, 'bus')
-    # For now, we only assume rabbitMQ as control bus always called 'broker_default'
-    rabbit_conf =  env["config"]['drivers'].get('broker-default')
+    # For now, we only assume rabbitMQ as control bus always called 'broker'
+    rabbit_conf =  env['config']['drivers'].get('broker')
     ansible_control_bus_conf = generate_ansible_conf(rabbit_conf, 'control-bus')
     # use deploy of each role
     extra_vars.update({"enos_action": "deploy"})


### PR DESCRIPTION
- Adapt campaign to use sweeper with bus drivers
- Sort campaign by agent type for execution
- Refactor ansible prepare config (this will allow us to add control_driver in conf or to expose --control in cli easier)
- Default values are in `conf.yaml` where the `broker` driver is mandatory for the task `prepare`
- Now the cli changed to: 

``` sh
./cli.py deploy --driver=broker g5k  # here the provider is mandatory
./cli.py test_case_2 --nbr_topics 10 {more options} 
./cli.py campaign --provider=g5k test_case_2 # here the test case is mandatory
```