### PR TITLE
Allow to choose where to bind clients and servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,13 @@ Grafana is available on the port 3000 of the control node (check the inventory f
 > It's possible to force an experimentation dir with `--env mydir`
 
 > Note also that scripting from python is also possible using the function defined in `task.py`
+
+## Misc.
+
+* Bound clients or servers to specific bus agents:
+
+To bind ombt-clients to a specific bus instance you can declare the following
+`roles: [bus, bus-client]`. 
+
+Following the same idea ombt-servers can be bound to a specific bus instance using 
+`roles: [bus, bus-server]`

--- a/conf.yaml
+++ b/conf.yaml
@@ -101,16 +101,7 @@ vagrant:
           - control_network
           - internal_network
       - roles:
-        - ombt-client
-        - telegraf
-        - chrony
-        flavor: tiny
-        number: 1
-        networks:
-          - control_network
-          - internal_network
-      - roles:
-        - ombt-server
+        - bus
         - telegraf
         - chrony
         flavor: tiny
@@ -120,6 +111,8 @@ vagrant:
           - internal_network
       - roles:
         - control-bus
+        - ombt-client
+        - ombt-server
         - ombt-control
         - control
         - registry
@@ -143,20 +136,10 @@ chameleon:
             flavor: m1.medium
             number: 1
           - roles:
-            - ombt-client
-            - telegraf
-            - chrony
-            flavor: m1.medium
-            number: 1
-          - roles:
-            - ombt-server
-            - telegraf
-            - chrony
-            flavor: m1.medium
-            number: 1
-          - roles:
             - control-bus
             - ombt-control
+            - ombt-server
+            - ombt-client
             - control
             - registry
             - telegraf


### PR DESCRIPTION
Optionnaly `bus-client` and `bus-server` can be specified in the
configuration file to force clients (resp. servers) to be attached on a
specific instance of the bus agent.
Note that a role `bus` is still required when specifying the two above
roles.