### PR TITLE
Start a rabbitmq master node first

### DIFF
--- a/orchestrator/ansible/roles/rabbitmq/tasks/deploy.yml
+++ b/orchestrator/ansible/roles/rabbitmq/tasks/deploy.yml
@@ -8,7 +8,7 @@
   template:
     src: "rabbitmq.config.j2"
     dest: "/etc/rabbitmq/{{ item.agent_id }}.config"
-  with_items: "{{ current_bus_conf }}"
+  loop: "{{ current_bus_conf }}"
   when: item.machine == inventory_hostname
 
 
@@ -18,36 +18,26 @@
 - name: Building the list of rabbit hosts (DNS)
   set_fact:
     etc_hosts: "{{ etc_hosts | default({}) | combine( {hostvars[item].ansible_hostname: hostvars[item]['ansible_' + control_network].ipv4.address} ) }}"
-  with_items: "{{ ansible_play_hosts }}"
+  loop: "{{ ansible_play_hosts }}"
 
-- name: Install and start docker image rabbitmq
-  docker_container:
-    name: "{{ item.agent_id }}"
-    image: rabbitmq:3-management
-    network_mode: host
-    state: started
-    etc_hosts: "{{ etc_hosts }}"
-    env:
-      RABBITMQ_NODENAME: "{{ item.agent_id }}@{{ ansible_hostname }}"
-      RABBITMQ_LOGS: rabbitmq.log
-      RABBITMQ_ERLANG_COOKIE: "secret_cookie"
-    volumes:
-      - "/etc/rabbitmq/{{ item.agent_id }}.config:/etc/rabbitmq/rabbitmq.config"
-      - "oo-{{ item.agent_id }}-logs:/var/log/rabbitmq"
-  with_items: "{{ current_bus_conf }}"
+
+# Code duplicated ahead
+# This might be factorize using loop and loop_control
+# when using ansible >= 2.7
+# 
+- include: start_single_rabbitmq.yml
+  loop: 
+    - "{{ current_bus_conf[0] }}"
   when: item.machine == inventory_hostname
 
-- name: Wait for the bus to be started
-  wait_for:
-    host: "{{ hostvars[inventory_hostname]['ansible_' + control_network]['ipv4']['address'] }}"
-    port: "{{ item.port }}"
-  with_items: "{{ current_bus_conf }}"
+- include: start_single_rabbitmq.yml
+  loop: "{{ current_bus_conf[1:] }}"
   when: item.machine == inventory_hostname
 
 # For an unknown reason the plugin isn't loaded automatically as before
 - name: Enabling the management interface
   command: "docker exec {{ item.agent_id }} rabbitmq-plugins enable rabbitmq_management"
-  with_items: "{{ current_bus_conf }}"
+  loop: "{{ current_bus_conf }}"
   when: item.machine == inventory_hostname
 
 

--- a/orchestrator/ansible/roles/rabbitmq/tasks/start_single_rabbitmq.yml
+++ b/orchestrator/ansible/roles/rabbitmq/tasks/start_single_rabbitmq.yml
@@ -1,0 +1,25 @@
+---
+- name: Install and start docker image rabbitmq
+  docker_container:
+    name: "{{ item.agent_id }}"
+    image: rabbitmq:3-management
+    network_mode: host
+    state: started
+    etc_hosts: "{{ etc_hosts }}"
+    env:
+      RABBITMQ_NODENAME: "{{ item.agent_id }}@{{ ansible_hostname }}"
+      RABBITMQ_LOGS: rabbitmq.log
+      RABBITMQ_ERLANG_COOKIE: "secret_cookie"
+    volumes:
+      - "/etc/rabbitmq/{{ item.agent_id }}.config:/etc/rabbitmq/rabbitmq.config"
+      - "oo-{{ item.agent_id }}-logs:/var/log/rabbitmq"
+  when:
+    - item.machine == inventory_hostname
+
+- name: Wait for the master bus to be started
+  wait_for:
+    host: "{{ hostvars[inventory_hostname]['ansible_' + control_network]['ipv4']['address'] }}"
+    port: "{{ item.port }}"
+  when:
+    - item.machine == inventory_hostname
+


### PR DESCRIPTION
RabbitMQ cluster doesn't start correctly if all instances are started in the
same time. We now start a first instance and wait for it to be up before
starting the others.