### PR TITLE
Determine previous and current it using all zip

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1,16 +1,17 @@
 campaign:
   test_case_1:
-    nbr_clients: [1]
-    nbr_servers: [1]
-    nbr_calls: [100000]
-    pause: [0]
+    nbr_clients: [1, 1, 1]
+    nbr_servers: [1, 1, 1]
+    nbr_calls: [100, 50, 25]
+    pause: [0.1, 0.2, 0.3]
     call_type: ["rpc-call"]
     timeout: [3600]
     version: ["msimonin/ombt:singleton"]
     length: [1024]
     executor: ["threading"]
     driver: ["broker", "router"]
-    delay: [null, 0ms, 10ms, 20ms, 30ms, 40ms, 50ms, 60ms, 70ms, 80ms, 90ms, 100ms]
+    delay: [null, 0ms, 10ms, 50ms]
+    loss: [0, 0.5, 1]
     traffic: ["tc-10"]
   test_case_2:
     nbr_topics: [10]

--- a/orchestrator/campaign.py
+++ b/orchestrator/campaign.py
@@ -138,8 +138,8 @@ def fix_1(parameters, current_parameters):
     {'nbr_clients': 1, 'nbr_servers': 4, 'topics': ['topic-0']}
     """
     # Note(msimonin): We may want to extend the get_current_value to all 'zip' elements
-    [p_clients, p_servers], [c_clients, c_servers] = get_current_values(
-        parameters, current_parameters, ["nbr_clients", "nbr_servers"])
+    [p_clients, p_servers, _, _], [c_clients, c_servers, _, _] = get_current_values(
+        parameters, current_parameters, ["nbr_clients", "nbr_servers", "nbr_calls", "pause"])
     current_parameters.update({"topics": ["topic-0"]})
     current_parameters.update({"nbr_clients": c_clients - p_clients})
     current_parameters.update({"nbr_servers": c_servers - p_servers})


### PR DESCRIPTION
```
    nbr_clients: [1, 1, 1]
    nbr_servers: [1, 1, 1]
    nbr_calls: [100, 50, 25]
    pause: [0.1, 0.2, 0.3]
```

nbr_calls and pause weren't taken into account in the previous iteration
calculation. The framework was misbehaving because, in the above, one new
client and server were started for each iteration.